### PR TITLE
feat: add dynamic product share metadata

### DIFF
--- a/app/productos/[slug]/page.tsx
+++ b/app/productos/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { Manrope, Sora } from "next/font/google";
 import { ShieldCheck, Truck } from "lucide-react";
@@ -21,6 +22,10 @@ const categoryLabel = {
   sincategoria: "",
 };
 
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://celulareslibresmedellin.co";
+const fallbackSocialImage = new URL("/og-whatsapp.png", siteUrl).toString();
+
 type Props = {
   params: Promise<{ slug: string }>;
 };
@@ -39,10 +44,76 @@ function normalizeDescription(product: Product) {
   return description;
 }
 
+function getAbsoluteUrl(value: string) {
+  if (/^https?:\/\//i.test(value)) return value;
+
+  const normalizedValue = value.startsWith("/") ? value : `/${value}`;
+  return new URL(normalizedValue, siteUrl).toString();
+}
+
+function buildProductDescription(product: Product) {
+  const priceLabel = formatCOP(product.price);
+  const description = normalizeDescription(product);
+
+  if (description) {
+    return `${priceLabel} · ${description}`;
+  }
+
+  return `${priceLabel} · Disponible en Celulares Libres Medellin.`;
+}
+
+async function getProductBySlug(slug: string) {
+  const products = await loadCatalog();
+  return products.find((item) => item.slug === slug) ?? null;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const product = await getProductBySlug(slug);
+
+  if (!product) {
+    return {
+      title: "Producto no encontrado",
+    };
+  }
+
+  const productUrl = new URL(`/productos/${product.slug}`, siteUrl).toString();
+  const socialImage = product.images[0]
+    ? getAbsoluteUrl(product.images[0])
+    : fallbackSocialImage;
+  const description = buildProductDescription(product);
+
+  return {
+    title: product.name,
+    description,
+    alternates: {
+      canonical: productUrl,
+    },
+    openGraph: {
+      type: "website",
+      locale: "es_CO",
+      url: productUrl,
+      title: product.name,
+      description,
+      images: [
+        {
+          url: socialImage,
+          alt: product.name,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: product.name,
+      description,
+      images: [socialImage],
+    },
+  };
+}
+
 export default async function ProductDetailPage({ params }: Props) {
   const { slug } = await params;
-  const products = await loadCatalog();
-  const product = products.find((item) => item.slug === slug);
+  const product = await getProductBySlug(slug);
 
   if (!product) {
     notFound();


### PR DESCRIPTION
## Summary
- add dynamic metadata generation for product detail pages
- expose product-specific title, price-based description, canonical URL and social preview image
- keep a fallback social image when a product has no gallery image
