### PR TITLE
fix: reuse shared product card in search

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,22 +1,13 @@
 "use client";
 
-import Image from "next/image";
 import { Manrope, Sora } from "next/font/google";
-import { ShoppingCart, ArrowUpDown, Search } from "lucide-react";
+import { ArrowUpDown, Search } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import {
-  Suspense,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type CSSProperties,
-} from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 
 import { type Product } from "@/lib/domain/product";
+import { ProductCard } from "@/app/components/product-card";
 import { useProductSearch } from "@/lib/services/product-search";
-import { useCartStore } from "@/lib/store/cart-store";
-import { formatCOP } from "@/lib/utils/format";
 
 import styles from "./search.module.css";
 
@@ -137,7 +128,6 @@ function getRevealDelay(index: number, columns: number) {
 }
 
 function SearchPageContent() {
-  const addItem = useCartStore((state) => state.addItem);
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -205,106 +195,6 @@ function SearchPageContent() {
   const resultLabel = displayQuery
     ? `${filteredProducts.length} resultado${filteredProducts.length === 1 ? "" : "s"} para “${displayQuery}”`
     : `${filteredProducts.length} producto${filteredProducts.length === 1 ? "" : "s"} disponibles`;
-
-  function ProductCard({
-    product,
-    delayMs,
-    isVisible,
-  }: {
-    product: Product;
-    delayMs: number;
-    isVisible: boolean;
-  }) {
-    const [showSecondImage, setShowSecondImage] = useState(false);
-    const primaryImage =
-      product.images[0] ??
-      "https://res.cloudinary.com/dwqyypb8q/image/upload/v1771952540/clm-logo_fyqsex.png";
-    const secondaryImage = product.images[1];
-    const hasSecondaryImage = Boolean(secondaryImage);
-    const hasPreviousPrice =
-      typeof product.previousPrice === "number" &&
-      product.previousPrice > product.price;
-    const cardStyle = { "--reveal-delay": `${delayMs}ms` } as CSSProperties;
-
-    return (
-      <article
-        className={`${styles.card} ${styles.cardReveal} ${isVisible ? styles.cardVisible : ""}`}
-        style={cardStyle}
-        role="link"
-        tabIndex={0}
-        onClick={() => router.push(`/productos/${product.slug}`)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            router.push(`/productos/${product.slug}`);
-          }
-        }}
-      >
-        <div
-          className={styles.imageWrap}
-          onPointerEnter={(event) => {
-            if (hasSecondaryImage && event.pointerType === "mouse") {
-              setShowSecondImage(true);
-            }
-          }}
-          onPointerLeave={(event) => {
-            if (event.pointerType === "mouse") {
-              setShowSecondImage(false);
-            }
-          }}
-        >
-          <Image
-            src={primaryImage}
-            alt={product.name}
-            fill
-            sizes="(max-width: 760px) 100vw, (max-width: 1100px) 50vw, 25vw"
-            className={`${styles.image} ${styles.imagePrimary} ${
-              hasSecondaryImage && showSecondImage ? styles.imageHidden : ""
-            }`}
-          />
-          {hasSecondaryImage && secondaryImage ? (
-            <Image
-              src={secondaryImage}
-              alt=""
-              fill
-              sizes="(max-width: 760px) 100vw, (max-width: 1100px) 50vw, 25vw"
-              className={`${styles.image} ${styles.imageSecondary} ${
-                showSecondImage ? styles.imageVisible : ""
-              }`}
-            />
-          ) : null}
-        </div>
-
-        <div className={styles.cardBody}>
-          <h2>{product.name}</h2>
-          <div className={styles.cardBottom}>
-            <div className={styles.priceStack}>
-              <strong>{formatCOP(product.price)}</strong>
-              <span
-                className={`${styles.previousPrice} ${hasPreviousPrice ? "" : styles.previousPriceEmpty}`}
-                aria-hidden={!hasPreviousPrice}
-              >
-                {hasPreviousPrice
-                  ? formatCOP(product.previousPrice!)
-                  : "\u00a0"}
-              </span>
-            </div>
-            <button
-              type="button"
-              aria-label={`Agregar ${product.name} al carrito`}
-              onClick={(event) => {
-                event.stopPropagation();
-                addItem(product);
-              }}
-            >
-              <ShoppingCart />
-              Agregar al carrito
-            </button>
-          </div>
-        </div>
-      </article>
-    );
-  }
 
   function ProductGrid({ items }: { items: Product[] }) {
     const { ref, isVisible } = useRevealOnView<HTMLDivElement>();


### PR DESCRIPTION
## Resumen\n- elimina la tarjeta local de la página de búsqueda\n- hace que /search reutilice la ProductCard compartida\n- alinea el comportamiento visual de search con el resto del catálogo\n\n## Resultado\n- search usa la misma tarjeta que productos y home