### PR TITLE
fix: add home page metadata

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,10 +4,18 @@ import { Manrope, Sora } from "next/font/google";
 import { ArrowRight, ArrowUpRight } from "lucide-react";
 import styles from "./home.module.css";
 import { FeaturedProductsGrid } from "./components/featured-products-grid";
+import { createPageMetadata } from "@/lib/site-metadata";
 import { loadCatalog } from "@/lib/server/catalog";
 
 const sora = Sora({ subsets: ["latin"], variable: "--font-display" });
 const manrope = Manrope({ subsets: ["latin"], variable: "--font-body" });
+
+export const metadata = createPageMetadata({
+  title: "Celulares Libres Medellin",
+  description:
+    "Compra celulares libres, ropa original, tecnología y accesorios bike en Medellin.",
+  path: "/",
+});
 
 const categories = [
   {


### PR DESCRIPTION
## Summary
- Adds explicit metadata for the home page using the shared `createPageMetadata` helper.

## Notes
The other routes React Doctor listed (`/carrito`, `/productos`, `/search`) already have route-level metadata in their `layout.tsx` files. Because those pages are Client Components, Next.js does not allow exporting `metadata` directly from the page file without splitting them into separate server/client files.

This PR handles the missing server page metadata without doing a larger route refactor.

## Verification
- `pnpm lint` ✅
- `pnpm exec tsc --noEmit` ✅
- `react-doctor` no longer reports `app/page.tsx` for `nextjs-missing-metadata` ✅
