### PR TITLE
perf: parallelize independent async work

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -263,32 +263,46 @@ async function optimizeImageForUpload(file: File): Promise<File> {
 
   context.drawImage(image, 0, 0, targetWidth, targetHeight);
 
-  let bestBlob: Blob | null = null;
+  const candidateSettings = ["image/webp", "image/jpeg"].flatMap((type) =>
+    OUTPUT_IMAGE_QUALITIES.map((quality) => ({ type, quality })),
+  );
+  const candidates = await Promise.all(
+    candidateSettings.map(async ({ type, quality }) => ({
+      type,
+      blob: await canvasToBlob(canvas, type, quality),
+    })),
+  );
 
-  for (const type of ["image/webp", "image/jpeg"]) {
-    for (const quality of OUTPUT_IMAGE_QUALITIES) {
-      const blob = await canvasToBlob(canvas, type, quality);
+  const selectedCandidate =
+    candidates.find(({ blob }) => blob.size <= MAX_UPLOAD_IMAGE_BYTES) ??
+    candidates.reduce<{ type: string; blob: Blob } | null>(
+      (smallest, candidate) => {
+        if (!smallest || candidate.blob.size < smallest.blob.size)
+          return candidate;
+        return smallest;
+      },
+      null,
+    );
 
-      if (!bestBlob || blob.size < bestBlob.size) {
-        bestBlob = blob;
-      }
-
-      if (blob.size <= MAX_UPLOAD_IMAGE_BYTES) {
-        const extension = type === "image/webp" ? ".webp" : ".jpg";
-        return new File([blob], renameFileExtension(file.name, extension), {
-          type,
-          lastModified: Date.now(),
-        });
-      }
-    }
-  }
-
-  if (!bestBlob) {
+  if (!selectedCandidate) {
     throw new Error(`No se pudo optimizar la imagen "${file.name}".`);
   }
 
-  throw new Error(
-    `La imagen "${file.name}" supera el límite permitido de ${formatFileSize(MAX_UPLOAD_IMAGE_BYTES)} incluso después de optimizarla.`,
+  const { type, blob } = selectedCandidate;
+
+  if (blob.size > MAX_UPLOAD_IMAGE_BYTES) {
+    throw new Error(
+      `La imagen "${file.name}" supera el límite permitido de ${formatFileSize(MAX_UPLOAD_IMAGE_BYTES)} incluso después de optimizarla.`,
+    );
+  }
+
+  return new File(
+    [blob],
+    renameFileExtension(file.name, type === "image/webp" ? ".webp" : ".jpg"),
+    {
+      type: blob.type || type,
+      lastModified: Date.now(),
+    },
   );
 }
 
@@ -802,45 +816,44 @@ export default function AdminPage() {
 
   async function uploadFilesToCloudinary(files: File[]): Promise<string[]> {
     const config = await getCloudinaryUploadConfig();
-    const urls: string[] = [];
 
-    for (const file of files) {
-      const payload = new FormData();
-      payload.append("file", file);
-      payload.append("folder", config.folder);
+    return Promise.all(
+      files.map(async (file) => {
+        const payload = new FormData();
+        payload.append("file", file);
+        payload.append("folder", config.folder);
 
-      if (config.mode === "signed") {
-        payload.append("timestamp", config.timestamp);
-        payload.append("api_key", config.apiKey);
-        payload.append("signature", config.signature);
-      } else {
-        payload.append("upload_preset", config.uploadPreset);
-      }
+        if (config.mode === "signed") {
+          payload.append("timestamp", config.timestamp);
+          payload.append("api_key", config.apiKey);
+          payload.append("signature", config.signature);
+        } else {
+          payload.append("upload_preset", config.uploadPreset);
+        }
 
-      const response = await fetch(
-        `https://api.cloudinary.com/v1_1/${config.cloudName}/image/upload`,
-        {
-          method: "POST",
-          body: payload,
-        },
-      );
-
-      const body = (await response.json().catch(() => null)) as {
-        secure_url?: string;
-        error?: { message?: string };
-      } | null;
-
-      if (!response.ok || !body?.secure_url) {
-        throw new Error(
-          body?.error?.message ||
-            `No se pudo subir la imagen "${file.name}" a Cloudinary.`,
+        const response = await fetch(
+          `https://api.cloudinary.com/v1_1/${config.cloudName}/image/upload`,
+          {
+            method: "POST",
+            body: payload,
+          },
         );
-      }
 
-      urls.push(body.secure_url);
-    }
+        const body = (await response.json().catch(() => null)) as {
+          secure_url?: string;
+          error?: { message?: string };
+        } | null;
 
-    return urls;
+        if (!response.ok || !body?.secure_url) {
+          throw new Error(
+            body?.error?.message ||
+              `No se pudo subir la imagen "${file.name}" a Cloudinary.`,
+          );
+        }
+
+        return body.secure_url;
+      }),
+    );
   }
 
   async function queuePendingFiles(files: File[]) {
@@ -849,26 +862,29 @@ export default function AdminPage() {
     setIsPreparingImages(true);
     setError("");
 
-    const pendingToAdd: PendingUpload[] = [];
-    const processingErrors: string[] = [];
-
     try {
-      for (const file of files) {
-        try {
+      const results = await Promise.allSettled(
+        files.map(async (file) => {
           const optimizedFile = await optimizeImageForUpload(file);
-          pendingToAdd.push({
+          return {
             tempUrl: URL.createObjectURL(optimizedFile),
             file: optimizedFile,
             name: file.name,
-          });
-        } catch (error) {
-          processingErrors.push(
-            error instanceof Error
-              ? error.message
-              : `No se pudo procesar la imagen "${file.name}".`,
-          );
-        }
-      }
+          } satisfies PendingUpload;
+        }),
+      );
+      const pendingToAdd = results.flatMap((result) =>
+        result.status === "fulfilled" ? [result.value] : [],
+      );
+      const processingErrors = results.flatMap((result, index) =>
+        result.status === "rejected"
+          ? [
+              result.reason instanceof Error
+                ? result.reason.message
+                : `No se pudo procesar la imagen "${files[index].name}".`,
+            ]
+          : [],
+      );
 
       if (pendingToAdd.length > 0) {
         setPendingUploads((prev) => [...prev, ...pendingToAdd]);

--- a/app/api/products/[slug]/route.ts
+++ b/app/api/products/[slug]/route.ts
@@ -7,8 +7,10 @@ type Context = {
 };
 
 export async function GET(_request: Request, context: Context) {
-  const { slug } = await context.params;
-  const catalog = await loadCatalog();
+  const [{ slug }, catalog] = await Promise.all([
+    context.params,
+    loadCatalog(),
+  ]);
   const product = catalog.find((item) => item.slug === slug);
 
   if (!product) {

--- a/lib/server/brands-admin.ts
+++ b/lib/server/brands-admin.ts
@@ -101,27 +101,28 @@ export async function createBrand(input: BrandInput): Promise<Brand> {
   const brand = normalizeBrand(input);
   const categoryId = await getCategoryIdBySlugForAdmin(brand.category);
 
-  const [slugConflict] = await database()
-    .select({ id: brands.id })
-    .from(brands)
-    .where(and(eq(brands.slug, brand.slug), isNull(brands.deletedAt)))
-    .limit(1);
+  const [[slugConflict], [nameConflict]] = await Promise.all([
+    database()
+      .select({ id: brands.id })
+      .from(brands)
+      .where(and(eq(brands.slug, brand.slug), isNull(brands.deletedAt)))
+      .limit(1),
+    database()
+      .select({ id: brands.id })
+      .from(brands)
+      .where(
+        and(
+          eq(brands.name, brand.name),
+          eq(brands.categoryId, categoryId),
+          isNull(brands.deletedAt),
+        ),
+      )
+      .limit(1),
+  ]);
 
   if (slugConflict) {
     throw new Error("Ya existe una marca con ese slug.");
   }
-
-  const [nameConflict] = await database()
-    .select({ id: brands.id })
-    .from(brands)
-    .where(
-      and(
-        eq(brands.name, brand.name),
-        eq(brands.categoryId, categoryId),
-        isNull(brands.deletedAt),
-      ),
-    )
-    .limit(1);
 
   if (nameConflict) {
     throw new Error("Ya existe una marca con ese nombre en la categoría.");
@@ -152,34 +153,35 @@ export async function updateBrand(input: BrandInput): Promise<Brand | null> {
   const updated = normalizeBrand({ ...current, ...input }, current);
   const categoryId = await getCategoryIdBySlugForAdmin(updated.category);
 
-  const [slugConflict] = await database()
-    .select({ id: brands.id })
-    .from(brands)
-    .where(
-      and(
-        eq(brands.slug, updated.slug),
-        isNull(brands.deletedAt),
-        sql`${brands.id} <> ${id}`,
-      ),
-    )
-    .limit(1);
+  const [[slugConflict], [nameConflict]] = await Promise.all([
+    database()
+      .select({ id: brands.id })
+      .from(brands)
+      .where(
+        and(
+          eq(brands.slug, updated.slug),
+          isNull(brands.deletedAt),
+          sql`${brands.id} <> ${id}`,
+        ),
+      )
+      .limit(1),
+    database()
+      .select({ id: brands.id })
+      .from(brands)
+      .where(
+        and(
+          eq(brands.name, updated.name),
+          eq(brands.categoryId, categoryId),
+          isNull(brands.deletedAt),
+          sql`${brands.id} <> ${id}`,
+        ),
+      )
+      .limit(1),
+  ]);
 
   if (slugConflict) {
     throw new Error("Ya existe una marca con ese slug.");
   }
-
-  const [nameConflict] = await database()
-    .select({ id: brands.id })
-    .from(brands)
-    .where(
-      and(
-        eq(brands.name, updated.name),
-        eq(brands.categoryId, categoryId),
-        isNull(brands.deletedAt),
-        sql`${brands.id} <> ${id}`,
-      ),
-    )
-    .limit(1);
 
   if (nameConflict) {
     throw new Error("Ya existe una marca con ese nombre en la categoría.");

--- a/lib/server/catalog-admin.ts
+++ b/lib/server/catalog-admin.ts
@@ -299,16 +299,16 @@ export async function createProduct(input: ProductInput): Promise<Product> {
   if (slugConflict) throw new SlugConflictError();
 
   const categoryId = await resolveCategoryId(product.category);
-  const subcategoryId = await resolveSubcategoryId(
-    product.subcategory,
-    categoryId,
-  );
-  const brandId = await resolveBrandId(product.brand, categoryId);
-
-  const [sort] = await database()
-    .select({ maxSort: sql<number>`coalesce(max(${products.sortOrder}), -1)` })
-    .from(products)
-    .where(isNull(products.deletedAt));
+  const [subcategoryId, brandId, [sort]] = await Promise.all([
+    resolveSubcategoryId(product.subcategory, categoryId),
+    resolveBrandId(product.brand, categoryId),
+    database()
+      .select({
+        maxSort: sql<number>`coalesce(max(${products.sortOrder}), -1)`,
+      })
+      .from(products)
+      .where(isNull(products.deletedAt)),
+  ]);
 
   const [inserted] = await database()
     .insert(products)
@@ -361,11 +361,10 @@ export async function updateProduct(
   }
 
   const categoryId = await resolveCategoryId(updated.category);
-  const subcategoryId = await resolveSubcategoryId(
-    updated.subcategory,
-    categoryId,
-  );
-  const brandId = await resolveBrandId(updated.brand, categoryId);
+  const [subcategoryId, brandId] = await Promise.all([
+    resolveSubcategoryId(updated.subcategory, categoryId),
+    resolveBrandId(updated.brand, categoryId),
+  ]);
   const removedImages = current.images.filter(
     (image) => !updated.images.includes(image),
   );
@@ -426,13 +425,14 @@ export async function reorderProducts(
   }
 
   await database().transaction(async (tx) => {
-    for (let index = 0; index < cleaned.length; index += 1) {
-      const id = cleaned[index];
-      await tx
-        .update(products)
-        .set({ sortOrder: index })
-        .where(and(eq(products.id, id), isNull(products.deletedAt)));
-    }
+    await Promise.all(
+      cleaned.map((id, index) =>
+        tx
+          .update(products)
+          .set({ sortOrder: index })
+          .where(and(eq(products.id, id), isNull(products.deletedAt))),
+      ),
+    );
   });
 
   const { products: reordered } = await getEditableCatalog();

--- a/lib/server/subcategories-admin.ts
+++ b/lib/server/subcategories-admin.ts
@@ -106,32 +106,33 @@ export async function createSubcategory(
   const subcategory = normalizeSubcategory(input);
   const categoryId = await getCategoryIdBySlugForAdmin(subcategory.category);
 
-  const [slugConflict] = await database()
-    .select({ id: subcategories.id })
-    .from(subcategories)
-    .where(
-      and(
-        eq(subcategories.slug, subcategory.slug),
-        isNull(subcategories.deletedAt),
-      ),
-    )
-    .limit(1);
+  const [[slugConflict], [nameConflict]] = await Promise.all([
+    database()
+      .select({ id: subcategories.id })
+      .from(subcategories)
+      .where(
+        and(
+          eq(subcategories.slug, subcategory.slug),
+          isNull(subcategories.deletedAt),
+        ),
+      )
+      .limit(1),
+    database()
+      .select({ id: subcategories.id })
+      .from(subcategories)
+      .where(
+        and(
+          eq(subcategories.name, subcategory.name),
+          eq(subcategories.categoryId, categoryId),
+          isNull(subcategories.deletedAt),
+        ),
+      )
+      .limit(1),
+  ]);
 
   if (slugConflict) {
     throw new Error("Ya existe una subcategoría con ese slug.");
   }
-
-  const [nameConflict] = await database()
-    .select({ id: subcategories.id })
-    .from(subcategories)
-    .where(
-      and(
-        eq(subcategories.name, subcategory.name),
-        eq(subcategories.categoryId, categoryId),
-        isNull(subcategories.deletedAt),
-      ),
-    )
-    .limit(1);
 
   if (nameConflict) {
     throw new Error(
@@ -166,34 +167,35 @@ export async function updateSubcategory(
   const updated = normalizeSubcategory({ ...current, ...input }, current);
   const categoryId = await getCategoryIdBySlugForAdmin(updated.category);
 
-  const [slugConflict] = await database()
-    .select({ id: subcategories.id })
-    .from(subcategories)
-    .where(
-      and(
-        eq(subcategories.slug, updated.slug),
-        isNull(subcategories.deletedAt),
-        sql`${subcategories.id} <> ${id}`,
-      ),
-    )
-    .limit(1);
+  const [[slugConflict], [nameConflict]] = await Promise.all([
+    database()
+      .select({ id: subcategories.id })
+      .from(subcategories)
+      .where(
+        and(
+          eq(subcategories.slug, updated.slug),
+          isNull(subcategories.deletedAt),
+          sql`${subcategories.id} <> ${id}`,
+        ),
+      )
+      .limit(1),
+    database()
+      .select({ id: subcategories.id })
+      .from(subcategories)
+      .where(
+        and(
+          eq(subcategories.name, updated.name),
+          eq(subcategories.categoryId, categoryId),
+          isNull(subcategories.deletedAt),
+          sql`${subcategories.id} <> ${id}`,
+        ),
+      )
+      .limit(1),
+  ]);
 
   if (slugConflict) {
     throw new Error("Ya existe una subcategoría con ese slug.");
   }
-
-  const [nameConflict] = await database()
-    .select({ id: subcategories.id })
-    .from(subcategories)
-    .where(
-      and(
-        eq(subcategories.name, updated.name),
-        eq(subcategories.categoryId, categoryId),
-        isNull(subcategories.deletedAt),
-        sql`${subcategories.id} <> ${id}`,
-      ),
-    )
-    .limit(1);
 
   if (nameConflict) {
     throw new Error(


### PR DESCRIPTION
## Summary
- Runs independent server validation queries in parallel for products, brands, and subcategories.
- Parallelizes independent product route parameter/catalog loading.
- Parallelizes reorder updates inside the existing transaction.
- Parallelizes independent admin image optimization and Cloudinary uploads while preserving per-file error reporting.

## Why
React Doctor reported `server-sequential-independent-await` and `async-await-in-loop` warnings in these areas. This PR removes those two categories from the report.

## Verification
- `pnpm lint` ✅
- `pnpm exec tsc --noEmit` ✅
- `npx --yes react-doctor . --full --json --no-score --fail-on none` ✅
  - `server-sequential-independent-await`: 0
  - `async-await-in-loop`: 0
